### PR TITLE
decoder: SIGSEGV with libnettle for special CipherInit call

### DIFF
--- a/src/crypto_nettle.c
+++ b/src/crypto_nettle.c
@@ -86,10 +86,10 @@ EXPORTED	CipherContext *	CipherInit(CipherContext * ctx, CipherMode mode, char *
 	if (!key && !iv)
 		return cipherCTX;
 
-	aes256_set_decrypt_key(&(ctx->cbc_context.ctx), (uint8_t *) key);
-	ctx->cipher_mode = mode;
+	aes256_set_decrypt_key(&(cipherCTX->cbc_context.ctx), (uint8_t *) key);
+	cipherCTX->cipher_mode = mode;
 	if (mode == CipherTypeValue)
-		CBC_SET_IV(&(ctx->cbc_context), iv);
+		CBC_SET_IV(&(cipherCTX->cbc_context), iv);
 
 	return cipherCTX;
 }

--- a/src/nettle/Makefile
+++ b/src/nettle/Makefile
@@ -1,4 +1,4 @@
-prj=nettle-3.3
+prj=nettle-3.4.1
 
 all:	$(prj) configure build install
 


### PR DESCRIPTION
Based on this issue: https://github.com/PeterPawn/decoder/issues/17