### PR TITLE
functions.h: Remove unused declaration

### DIFF
--- a/src/functions.h
+++ b/src/functions.h
@@ -29,8 +29,6 @@
 
 typedef struct commandEntry commandEntry_t;
 
-void (*usageScreen)(void);
-
 struct commandEntry {
 	char * *		*names;
 	int 			(*ep)(int argc, char **argv, int argo, commandEntry_t * entry);


### PR DESCRIPTION
This also fixes multiple definition errors when using gcc 10 (caused by
omitting "extern"):

```
make -C src
make[1]: Entering directory '/home/juergen/tmp/decoder/src'
gcc -static -Wl,--gc-sections -L. -o decoder errors.o output.o base32.o base64.o hex.o encryption.o exportfile.o memory.o functions.o crypto_nettle.o options.o environ.o license.o crc32.o help.o decfile.o decexp.o deccb.o decompose.o decsngl.o pkpwd.o checksum.o userpw.o devpw.o pwfrdev.o b32dec.o b32enc.o b64dec.o b64enc.o hexdec.o hexenc.o decoder.o -lnettle
/usr/bin/ld: output.o:(.bss.usageScreen+0x0): multiple definition of `usageScreen'; errors.o:(.bss.usageScreen+0x0): first defined here
/usr/bin/ld: base32.o:(.bss.usageScreen+0x0): multiple definition of `usageScreen'; errors.o:(.bss.usageScreen+0x0): first defined here
/usr/bin/ld: base64.o:(.bss.usageScreen+0x0): multiple definition of `usageScreen'; errors.o:(.bss.usageScreen+0x0): first defined here
/usr/bin/ld: hex.o:(.bss.usageScreen+0x0): multiple definition of `usageScreen'; errors.o:(.bss.usageScreen+0x0): first defined here
/usr/bin/ld: encryption.o:(.bss.usageScreen+0x0): multiple definition of `usageScreen'; errors.o:(.bss.usageScreen+0x0): first defined here
/usr/bin/ld: exportfile.o:(.bss.usageScreen+0x0): multiple definition of `usageScreen'; errors.o:(.bss.usageScreen+0x0): first defined here
/usr/bin/ld: memory.o:(.bss.usageScreen+0x0): multiple definition of `usageScreen'; errors.o:(.bss.usageScreen+0x0): first defined here
/usr/bin/ld: functions.o:(.bss.usageScreen+0x0): multiple definition of `usageScreen'; errors.o:(.bss.usageScreen+0x0): first defined here
/usr/bin/ld: crypto_nettle.o:(.bss.usageScreen+0x0): multiple definition of `usageScreen'; errors.o:(.bss.usageScreen+0x0): first defined here
/usr/bin/ld: options.o:(.bss.usageScreen+0x0): multiple definition of `usageScreen'; errors.o:(.bss.usageScreen+0x0): first defined here
/usr/bin/ld: environ.o:(.bss.usageScreen+0x0): multiple definition of `usageScreen'; errors.o:(.bss.usageScreen+0x0): first defined here
/usr/bin/ld: license.o:(.bss.usageScreen+0x0): multiple definition of `usageScreen'; errors.o:(.bss.usageScreen+0x0): first defined here
/usr/bin/ld: crc32.o:(.bss.usageScreen+0x0): multiple definition of `usageScreen'; errors.o:(.bss.usageScreen+0x0): first defined here
/usr/bin/ld: help.o:(.bss.usageScreen+0x0): multiple definition of `usageScreen'; errors.o:(.bss.usageScreen+0x0): first defined here
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:746: decoder] Error 1
make[1]: Leaving directory '/home/juergen/tmp/decoder/src'
make: *** [Makefile:24: decoder] Error 2
```

[GCC 10 porting guide](https://gcc.gnu.org/gcc-10/porting_to.html)