### PR TITLE
decider: fix build failure against gcc-10 (-fno-common)

### DIFF
--- a/src/functions.h
+++ b/src/functions.h
@@ -29,8 +29,6 @@
 
 typedef struct commandEntry commandEntry_t;
 
-void (*usageScreen)(void);
-
 struct commandEntry {
 	char * *		*names;
 	int 			(*ep)(int argc, char **argv, int argo, commandEntry_t * entry);


### PR DESCRIPTION
gcc-10 changed the default from -fcommon to fno-common:
  https://gcc.gnu.org/PR85678

As a result build fails as:

    ld: decoder.o:(.bss.usageScreen+0x0): multiple definition of
      `usageScreen'; errors.o:(.bss.usageScreen+0x0): first defined here

The change drops unused `usageScreen` definition from `.h` file.